### PR TITLE
Update http service to allow sending data other than json

### DIFF
--- a/generators/app/templates/src/main/client/javascript/services/api/http.js
+++ b/generators/app/templates/src/main/client/javascript/services/api/http.js
@@ -52,9 +52,24 @@ export const request = (path, method = 'GET', body = null, headers = {}) => {
     });
 };
 
+const hasHeader = (headers = {}, headerName) =>
+  Object
+    .keys(headers)
+    .some(key => key.toLowerCase() === headerName.toLowerCase());
+
+const requestWithData = (path, method, data, headers = {}) => {
+  const headerContentType = 'Content-Type';
+  // Don't modify for FormData or request with existing content-type header set
+  if (data instanceof FormData || hasHeader(headers, headerContentType)) {
+    return request(path, method, data, headers);
+  }
+  // Otherwise default to JSON
+  return request(path, method, JSON.stringify(data), { [headerContentType]: 'application/json', ...headers });
+};
+
 export const requestJSON = (path, method, data, headers = {}) => (
   (data
-      ? request(path, method, JSON.stringify(data), { 'Content-Type': 'application/json', ...headers })
+      ? requestWithData(path, method, data, headers)
       : request(path, method, null, headers)
   ).then(response => (response.status !== 204 ? response.json() : null))
 );

--- a/generators/app/templates/src/test/javascript/services/api/http.test.js
+++ b/generators/app/templates/src/test/javascript/services/api/http.test.js
@@ -1,0 +1,54 @@
+import { find } from 'lodash';
+import { requestJSON } from '../../../../main/client/javascript/services/api/http';
+
+describe('Service: http', () => {
+  let request;
+
+  beforeEach(() => {
+    global.fetch = jest.fn().mockImplementation(
+      (url, config) => {
+        request = { url, config };
+        return new Promise((resolve) => {
+          resolve({
+            ok: true,
+            id: '123',
+            json: () => ({ id: '123' }),
+          });
+        });
+      });
+  });
+
+  describe('requestJSON', () => {
+    const findHeader = (headers, header) =>
+      find(headers, (value, key) => key.toLowerCase() === header.toLowerCase());
+
+    test('will prepend baseUrl to url', () => {
+      requestJSON('/something/123', 'GET', { id: 'abc' }, {});
+
+      expect(request.url).toBe('/api/v1/something/123');
+    });
+
+    test('will default to json if no Content-Type specified', () => {
+      requestJSON('/something/123', 'GET', { id: 'abc' }, {});
+
+      expect(findHeader(request.config.headers, 'Content-Type')).toBe('application/json');
+      expect(request.config.body).toBe('{"id":"abc"}');
+    });
+
+    test('will not modify content-type if header already exists', () => {
+      const data = { id: 'abc' };
+      requestJSON('/something/123', 'GET', data, { 'content-type': 'text/plain' });
+
+      expect(request.config.body).toBe(data);
+      expect(findHeader(request.config.headers, 'Content-Type')).toBe('text/plain');
+    });
+
+    test('will not modify content-type if data is FormData', () => {
+      const data = new FormData();
+      requestJSON('/something/123', 'GET', data, {});
+
+      expect(request.config.body).toBe(data);
+      expect(findHeader(request.config.headers, 'Content-Type')).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
I've added some logic to requestJSON to not modify data and headers for requests sending FormData OR when a Content-type header has already been specified.

At the moment requestJSON function assumes that JSON is sent and returned. I expected it to be mean that JSON would be returned but not necessarily be sent (i.e. for a GET we don't send anything). The specific issue I had was trying to sending a FormData object (which ends up as a MultipartFile in controller).
